### PR TITLE
[W5.11][W09-02] David Livingston

### DIFF
--- a/docs/UserGuide.adoc
+++ b/docs/UserGuide.adoc
@@ -69,9 +69,9 @@ Examples:
 
 [TIP]
 ====
-The name should only have alphabetic characters and spaces. The phone number should only consist of digits.
-The email address has to be entered in the appropriate format: `email@domain.com`. Following this tip can help prevent
-the program from raising an exception.
+The name should only have alphabetic characters, hypens, dashes and spaces. The entered phone number should consist only
+ of digits. The email address has to be entered in the appropriate format: `email@domain.com`. The program will throw an
+ exception if the data entered is not in the correct format.
 ====
 
 == Listing all persons : `list`

--- a/docs/UserGuide.adoc
+++ b/docs/UserGuide.adoc
@@ -67,6 +67,13 @@ Examples:
 * `add John Doe p/98765432 e/johnd@gmail.com a/John street, block 123, #01-01`
 * `add Betsy Crowe pp/1234567 e/betsycrowe@gmail.com pa/Newgate Prison t/criminal t/friend`
 
+[TIP]
+====
+The name should only have alphabetic characters and spaces. The phone number should only consist of digits.
+The email address has to be entered in the appropriate format: `email@domain.com`. Following this tip can help prevent
+the program from raising an exception.
+====
+
 == Listing all persons : `list`
 
 Shows a list of all persons, along with their non-private details, in the address book. +

--- a/src/seedu/addressbook/Main.java
+++ b/src/seedu/addressbook/Main.java
@@ -126,6 +126,12 @@ public class Main {
         boolean isStorageFileSpecifiedByUser = launchArgs.length > 0;
         return isStorageFileSpecifiedByUser ? new StorageFile(launchArgs[0]) : new StorageFile();
     }
-
+// TODO
+    // 1. Update user guide
+    // 2. Update developer guide
+    // 3. Make a small change
+    // 4. Update tests and add new tests - for both JUnit and I/O tests
+    // 5. Follow coding style
+    // 6. Follow OOP concepts
 
 }

--- a/src/seedu/addressbook/Main.java
+++ b/src/seedu/addressbook/Main.java
@@ -126,12 +126,5 @@ public class Main {
         boolean isStorageFileSpecifiedByUser = launchArgs.length > 0;
         return isStorageFileSpecifiedByUser ? new StorageFile(launchArgs[0]) : new StorageFile();
     }
-// TODO
-    // 1. Update user guide
-    // 2. Update developer guide
-    // 3. Make a small change
-    // 4. Update tests and add new tests - for both JUnit and I/O tests
-    // 5. Follow coding style
-    // 6. Follow OOP concepts
 
 }

--- a/src/seedu/addressbook/data/person/Email.java
+++ b/src/seedu/addressbook/data/person/Email.java
@@ -11,7 +11,7 @@ public class Email {
     public static final String EXAMPLE = "valid@e.mail";
     public static final String MESSAGE_EMAIL_CONSTRAINTS =
             "Person emails should be 2 alphanumeric/period strings separated by '@'";
-    public static final String EMAIL_VALIDATION_REGEX = "[\\w\\.]+@[\\w\\.]+";
+    public static final String EMAIL_VALIDATION_REGEX = "[\\w.]+@[\\w.]+";
 
     public final String value;
     private boolean isPrivate;

--- a/src/seedu/addressbook/data/person/Name.java
+++ b/src/seedu/addressbook/data/person/Name.java
@@ -13,7 +13,7 @@ public class Name {
 
     public static final String EXAMPLE = "John Doe";
     public static final String MESSAGE_NAME_CONSTRAINTS = "Person names should be spaces or alphabetic characters";
-    public static final String NAME_VALIDATION_REGEX = "[\\p{Alpha} ]+";
+    public static final String NAME_VALIDATION_REGEX = "^[\\p{L} .'-]+$";
     public final String fullName;
 
     /**

--- a/test/expected.txt
+++ b/test/expected.txt
@@ -135,6 +135,12 @@
 || 
 || 5 persons listed!
 || ===================================================
+|| Enter command: || [Command entered:  add Valid-Name p/12345 e/valid@email.com a/alice in wonderland]
+|| New person added: Valid-Name Phone: 12345 Email: valid@email.com Address: alice in wonderland Tags: 
+|| ===================================================
+|| Enter command: || [Command entered:  add Valid'Name p/12398 e/testValidname@gmail.com a/valid address]
+|| New person added: Valid'Name Phone: 12398 Email: testValidname@gmail.com Address: valid address Tags: 
+|| ===================================================
 || Enter command: || [Command entered:  add Esther Potato p/555555 e/esther@not.a.real.potato pa/555, epsilon street t/tubers t/starchy]
 || This person already exists in the address book
 || ===================================================
@@ -268,8 +274,10 @@
 || 	2. Betsy Choo Tags: [secretive]
 || 	3. Dickson Ee Phone: 444444 Address: 444, delta street Tags: [friends]
 || 	4. Esther Potato Phone: 555555 Email: esther@not.a.real.potato Tags: [tubers][starchy]
+|| 	5. Valid-Name Phone: 12345 Email: valid@email.com Address: alice in wonderland Tags: 
+|| 	6. Valid'Name Phone: 12398 Email: testValidname@gmail.com Address: valid address Tags: 
 || 
-|| 4 persons listed!
+|| 6 persons listed!
 || ===================================================
 || Enter command: || [Command entered:  delete 4]
 || Deleted Person: Esther Potato Phone: 555555 Email: esther@not.a.real.potato Address: (private) 555, epsilon street Tags: [tubers][starchy]
@@ -278,8 +286,10 @@
 || 	1. Adam Brown Phone: 111111 Email: adam@gmail.com Address: 111, alpha street Tags: 
 || 	2. Betsy Choo Tags: [secretive]
 || 	3. Dickson Ee Phone: 444444 Address: 444, delta street Tags: [friends]
+|| 	4. Valid-Name Phone: 12345 Email: valid@email.com Address: alice in wonderland Tags: 
+|| 	5. Valid'Name Phone: 12398 Email: testValidname@gmail.com Address: valid address Tags: 
 || 
-|| 3 persons listed!
+|| 5 persons listed!
 || ===================================================
 || Enter command: || [Command entered:  delete 1]
 || Deleted Person: Adam Brown Phone: 111111 Email: adam@gmail.com Address: 111, alpha street Tags: 
@@ -287,8 +297,10 @@
 || Enter command: || [Command entered:  list]
 || 	1. Betsy Choo Tags: [secretive]
 || 	2. Dickson Ee Phone: 444444 Address: 444, delta street Tags: [friends]
+|| 	3. Valid-Name Phone: 12345 Email: valid@email.com Address: alice in wonderland Tags: 
+|| 	4. Valid'Name Phone: 12398 Email: testValidname@gmail.com Address: valid address Tags: 
 || 
-|| 2 persons listed!
+|| 4 persons listed!
 || ===================================================
 || Enter command: || [Command entered:  clear]
 || Address book has been cleared!

--- a/test/input.txt
+++ b/test/input.txt
@@ -50,6 +50,8 @@
   list
   add Esther Potato p/555555 e/esther@not.a.real.potato pa/555, epsilon street t/tubers t/starchy
   list
+  add Valid-Name p/12345 e/valid@email.com a/alice in wonderland
+  add Valid'Name p/12398 e/testValidname@gmail.com a/valid address
 
   # should not allow adding duplicate persons
   add Esther Potato p/555555 e/esther@not.a.real.potato pa/555, epsilon street t/tubers t/starchy

--- a/test/java/seedu/addressbook/commands/AddCommandTest.java
+++ b/test/java/seedu/addressbook/commands/AddCommandTest.java
@@ -105,8 +105,6 @@ public class AddCommandTest {
                 Address.EXAMPLE, true, EMPTY_STRING_SET);
         ReadOnlyPerson p = command.getPerson();
 
-        // TODO: add comparison of tags to person.equals and equality methods to
-        // individual fields that compare privacy to simplify this
         assertEquals(Name.EXAMPLE, p.getName().fullName);
         assertEquals(Phone.EXAMPLE, p.getPhone().value);
         assertTrue(p.getPhone().isPrivate());

--- a/test/java/seedu/addressbook/commands/AddCommandTest.java
+++ b/test/java/seedu/addressbook/commands/AddCommandTest.java
@@ -22,11 +22,13 @@ import seedu.addressbook.data.person.Person;
 import seedu.addressbook.data.person.Phone;
 import seedu.addressbook.data.person.ReadOnlyPerson;
 import seedu.addressbook.data.person.UniquePersonList;
+import seedu.addressbook.data.tag.Tag;
 import seedu.addressbook.util.TestUtil;
 
 public class AddCommandTest {
     private static final List<ReadOnlyPerson> EMPTY_PERSON_LIST = Collections.emptyList();
     private static final Set<String> EMPTY_STRING_SET = Collections.emptySet();
+    private static final Set<Tag> EMPTY_TAG_SET = Collections.emptySet();
 
     @Test
     public void addCommand_invalidName_throwsException() {
@@ -39,7 +41,9 @@ public class AddCommandTest {
 
     @Test
     public void addCommand_invalidPhone_throwsException() {
-        final String[] invalidNumbers = { "", " ", "1234-5678", "[]\\[;]", "abc", "a123", "+651234" };
+        final String[] invalidNumbers = { "", " ", "1234-5678", "[]\\[;]",
+            "abc", "a123", "+651234", "9123 1234", "812 123 124",
+            "123-123-123"};
         for (String number : invalidNumbers) {
             assertConstructingInvalidAddCmdThrowsException(Name.EXAMPLE, number, false, Email.EXAMPLE, true,
                     Address.EXAMPLE, false, EMPTY_STRING_SET);
@@ -112,6 +116,7 @@ public class AddCommandTest {
         assertTrue(p.getAddress().isPrivate());
         boolean isTagListEmpty = !p.getTags().iterator().hasNext();
         assertTrue(isTagListEmpty);
+        assertEquals(p.getTags(), EMPTY_TAG_SET);
     }
 
     @Test

--- a/test/java/seedu/addressbook/storage/StorageFileTest.java
+++ b/test/java/seedu/addressbook/storage/StorageFileTest.java
@@ -60,7 +60,6 @@ public class StorageFileTest {
         AddressBook expectedAB = getTestAddressBook();
 
         // ensure loaded AddressBook is properly constructed with test data
-        // TODO: overwrite equals method in AddressBook class and replace with equals method below
         assertEquals(actualAB.getAllPersons(), expectedAB.getAllPersons());
     }
 


### PR DESCRIPTION
**Input validation**
Previously, the name input is unable to take in names with hypens, dots and apostrophes, which can be rather restrictive. Now, with the updated regex check for the name input, more types of names can be taken in. 

There is also a minor issue with the regex check for the email: 
`"[\\w\\.]+@[\\w\\.]+"` 
The escape sequence before the '.' does not serve any purpose. This issue has been rectified in this pull request. 

The user guide also has been updated to include a tip with regards to the types of input the user can key in. 

In this pull request, the test cases for both the I/O tests and JUnit tests have also been expanded to improve test coverage. 

